### PR TITLE
Add missing lock for IndividualAcknowledgeAsync

### DIFF
--- a/src/ArtemisNetCoreClient/Session.cs
+++ b/src/ArtemisNetCoreClient/Session.cs
@@ -348,6 +348,7 @@ internal class Session(Connection connection, ILoggerFactory loggerFactory) : IS
             MessageId = messageDelivery.MessageId,
             RequiresResponse = true,
         };
+        await _lock.WaitAsync(cancellationToken);
         try
         {
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -359,6 +360,10 @@ internal class Session(Connection connection, ILoggerFactory loggerFactory) : IS
         {
             _completionSources.TryRemove(-1, out _);
             throw;
+        }
+        finally
+        {
+            _lock.Release();
         }
     }
     


### PR DESCRIPTION
It's required because `SessionIndividualAcknowledgeMessage` does not allow passing a `CorrelationId`; it always uses -1.