### PR TITLE
Add synchronous acknowledgment methods to IConsumer interface

### DIFF
--- a/src/ArtemisNetCoreClient/Consumer.cs
+++ b/src/ArtemisNetCoreClient/Consumer.cs
@@ -44,6 +44,16 @@ internal class Consumer : IConsumer
         return _session.IndividualAcknowledgeAsync(messageDelivery, cancellationToken);
     }
 
+    public void Acknowledge(in MessageDelivery messageDelivery)
+    {
+        _session.Acknowledge(messageDelivery);
+    }
+
+    public void IndividualAcknowledge(in MessageDelivery messageDelivery)
+    {
+        _session.IndividualAcknowledge(messageDelivery);
+    }
+
     internal void OnMessage(ReceivedMessage message)
     {
         // TODO: What if try write is false?

--- a/src/ArtemisNetCoreClient/IConsumer.cs
+++ b/src/ArtemisNetCoreClient/IConsumer.cs
@@ -15,4 +15,18 @@ public interface IConsumer : IAsyncDisposable
     /// <param name="messageDelivery">Delivery information of a message to acknowledge.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     ValueTask IndividualAcknowledgeAsync(in MessageDelivery messageDelivery, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Acknowledges all messages received by the consumer. It doesn't wait for the confirmation from the broker.
+    /// It's a fire-and-forget operation. If you need to wait for the confirmation, use <see cref="AcknowledgeAsync"/> instead.
+    /// </summary>
+    /// <param name="messageDelivery">Delivery information of a last message to acknowledge.</param>
+    void Acknowledge(in MessageDelivery messageDelivery);
+    
+    /// <summary>
+    /// Acknowledges the message without waiting for the confirmation from the broker.
+    /// It's a fire-and-forget operation. If you need to wait for the confirmation, use <see cref="IndividualAcknowledgeAsync"/> instead.
+    /// </summary>
+    /// <param name="messageDelivery">Delivery information of a message to acknowledge.</param>
+    void IndividualAcknowledge(in MessageDelivery messageDelivery);
 }

--- a/src/ArtemisNetCoreClient/Session.cs
+++ b/src/ArtemisNetCoreClient/Session.cs
@@ -433,6 +433,28 @@ internal class Session(Connection connection, ILoggerFactory loggerFactory) : IS
             _lock.Release();
         }
     }
+    
+    public void Acknowledge(in MessageDelivery messageDelivery)
+    {
+        var request = new SessionAcknowledgeMessage
+        {
+            ConsumerId = messageDelivery.ConsumerId,
+            MessageId = messageDelivery.MessageId,
+            RequiresResponse = false,
+        };
+        connection.Send(request, ChannelId);
+    }
+    
+    public void IndividualAcknowledge(in MessageDelivery messageDelivery)
+    {
+        var request = new SessionIndividualAcknowledgeMessage
+        {
+            ConsumerId = messageDelivery.ConsumerId,
+            MessageId = messageDelivery.MessageId,
+            RequiresResponse = false,
+        };
+        connection.Send(request, ChannelId);
+    }
 
     public async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
This commit introduces two new methods to the IConsumer interface:
1. `Acknowledge`, which provides a fire-and-forget mechanism for acknowledging all messages received by the consumer. This method does not wait for broker confirmation.
2. `IndividualAcknowledge`, similar to `Acknowledge`, but used for acknowledging individual messages without waiting for broker confirmation.

Both methods are intended for scenarios where waiting for acknowledgment confirmation is not required, enhancing flexibility in message processing.